### PR TITLE
Mark devversion as OOO in PullApprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -57,7 +57,8 @@
 version: 3
 
 availability:
-  users_unavailable: []
+  users_unavailable:
+    - devversion
 
 # Meta field that goes unused by PullApprove to allow for defining aliases to be
 # used throughout the config.


### PR DESCRIPTION
Marked 'devversion' as unavailable in .pullapprove.yml on a new branch 'ooo-devversion' synced with upstream Angular main.

---
*PR created automatically by Jules for task [16802859354610038917](https://jules.google.com/task/16802859354610038917) started by @devversion*